### PR TITLE
Better handling of constant variables

### DIFF
--- a/src/coordinate_descent.jl
+++ b/src/coordinate_descent.jl
@@ -519,7 +519,8 @@ function cycle!(coef::SparseCoefficients{T}, cd::CovarianceCoordinateDescent{T},
             end
 
             λωj = λω(λ,ω,ipred)
-            newcoef = S(s, λωj*α)/(Xssq[ipred] + λωj*(1 - α))
+            _ssq = Xssq[ipred]
+            newcoef = _ssq > zero(T) ? S(s, λωj*α)/(_ssq + λωj*(1 - α)) : zero(T)
             if oldcoef != newcoef
                 if icoef == 0
                     # Adding a new variable to the model


### PR DESCRIPTION
When fitting a LassoPath for `\alpha=1`, if a column of `X` is all zero, or when it is constant and centralization is requested, `Lasso.fit` fails with a `"coordinate descent failed to converge in $maxiter iterations at λ = $λ"` error.

The culprit is a `0/0` case which is addressed in this PR.

However I am unsure of the following:
1. When `\alpha < 1`, is there any practical use for the coef of a constant (but non-intercept) variable to be non-zero? If so then the fix should be reconsidered.
2. Should we just fail gracefully instead of trying to proceed for this pathological input?

Any suggestions much appreciated.