### PR TITLE
Type safe regularization path segment selection

### DIFF
--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -349,6 +349,82 @@ function standardizeX(X::AbstractMatrix{T}, standardize::Bool) where T
     X, Xnorm
 end
 
+"""
+    fit(LassoPath, X, y, d=Normal(), l=canonicallink(d); ...)   
+    
+fits a linear or generalized linear Lasso path given the design
+matrix `X` and response `y`:
+
+``\\underset{\\beta}{\\operatorname{argmin}} -\\frac{1}{N} \\mathcal{L}(y|X,\\beta) 
++ \\lambda\\left[(1-\\alpha)\\frac{1}{2}\\|\\beta\\|_2^2 + \\alpha\\|\\beta\\|_1\\right]``
+
+The optional argument `d` specifies the conditional distribution of
+response, while `l` specifies the link function. Lasso.jl inherits
+supported distributions and link functions from GLM.jl. The default
+is to fit an linear Lasso path, i.e., `d=Normal(), l=IdentityLink()`,
+or ``\\mathcal{L}(y|X,\\beta) = -\\frac{1}{2}\\|y - X\\beta\\|_2^2 + C``
+
+# Examples
+```julia
+fit(LassoPath, X, y)    # L1-regularized linear regression
+fit(LassoPath, X, y, Binomial(), Logit(); 
+    α=0.5) # Binomial logit regression with an Elastic net combination of 
+           # 0.5 L1 and 0.5 L2 regularization penalties
+```
+# Arguments
+- `wts=ones(length(y))`: Weights for each observation                                    
+- `offset=zeros(length(y))`: Offset of each observation                                    
+- `λ`: can be used to specify a specific set of λ values at which models are fit. 
+    If λ is unspecified, Lasso.jl selects nλ logarithmically spaced λ values from
+    `λmax`, the smallest λ value yielding a null model, to
+    `λminratio * λmax`.
+- `nλ=100` number of λ values to use
+- `λminratio=1e-4` if more observations than predictors otherwise 0.001.
+- `stopearly=true`: When `true`, if the proportion of deviance explained 
+    exceeds 0.999 or the difference between the deviance explained by successive λ
+    values falls below `1e-5`, the path stops early.                                    
+- `standardize=true`: Whether to standardize predictors to unit standard deviation 
+    before fitting.                              
+- `intercept=true`: Whether to fit an (unpenalized) model intercept.
+- `algorithm`: Algorithm to use. 
+    `NaiveCoordinateDescent` iteratively computes the dot product of the 
+    predictors with the  residuals, as opposed to the         
+    `CovarianceCoordinateDescent` algorithm, which uses a precomputed Gram matrix.                
+    `NaiveCoordinateDescent` is typically faster when there are many  
+    predictors that will not enter the model or when fitting        
+    generalized linear models.                                      
+    By default uses `NaiveCoordinateDescent` if more than 5x as many predictors 
+    as observations or model is a GLM. `CovarianceCoordinateDescent` otherwise.
+- `randomize=true`: Whether to randomize the order in which coefficients are
+    updated by coordinate descent. This can drastically speed
+    convergence if coefficients are highly correlated.
+- `maxncoef=min(size(X, 2), 2*size(X, 1))`: maximum number of coefficients 
+    allowed in the model. If exceeded, an error will be thrown.
+- `dofit=true`: Whether to fit the model upon construction. If `false`, the 
+    model can be fit later by calling `fit!(model)`.
+- `cd_tol=1e-7`: The tolerance for coordinate descent iterations iterations in
+    the inner loop.
+- `irls_tol=1e-7`: The tolerance for outer iteratively reweighted least squares
+    iterations. This is ignored unless the model is a generalized linear model.
+- `criterion=:coef` Convergence criterion. Controls how ``cd_tol`` and ``irls_tol``
+    are to be interpreted. Possible values are:
+    - ``:coef``: The model is considered to have converged if the
+    the maximum absolute squared difference in coefficients
+    between successive iterations drops below the specified
+    tolerance. This is the criterion used by glmnet.
+    - ``:obj``: The model is considered to have converged if the
+    the relative change in the Lasso/Elastic Net objective
+    between successive iterations drops below the specified
+    tolerance. This is the criterion used by GLM.jl.
+- `minStepFac=0.001`: The minimum step fraction for backtracking line search.
+- `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\\omega_j`` 
+    for each coefficient ``j``, i.e. instead of ``\\lambda`` penalties become
+    ``\\lambda\\omega_j``.
+    Note the penalty factors are internally rescaled to sum to
+    the number of variables (`glmnet.R` convention).
+- `standardizeω=true`: Whether to scale penalty factors to sum to the number of
+    variables (glmnet.R convention).
+"""
 function StatsBase.fit(::Type{LassoPath},
                        X::AbstractMatrix{T}, y::V, d::UnivariateDistribution=Normal(),
                        l::Link=canonicallink(d);

--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -19,7 +19,8 @@ export RegularizationPath, LassoPath, GammaLassoPath, NaiveCoordinateDescent,
        CovarianceCoordinateDescent, fit, fit!, coef, predict,
        minAICc, hasintercept, dof, aicc, distfun, linkfun, cross_validate_path,
        SegSelect, segselect,
-       AllSeg, MinAIC, MinAICc, MinBIC, CVSegSelect, MinCVmse, MinCV1se
+       AllSeg, MinAIC, MinAICc, MinBIC, CVSegSelect, MinCVmse, MinCV1se,
+       GammaLasso
 
 
 ## HELPERS FOR SPARSE COEFFICIENTS

--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -17,7 +17,9 @@ import Random: Sampler
 using GLM: FPVector
 export RegularizationPath, LassoPath, GammaLassoPath, NaiveCoordinateDescent,
        CovarianceCoordinateDescent, fit, fit!, coef, predict,
-       minAICc, hasintercept, dof, aicc, distfun, linkfun, cross_validate_path
+       minAICc, hasintercept, dof, aicc, distfun, linkfun, cross_validate_path,
+       SegSelect, segselect,
+       AllSeg, MinAIC, MinAICc, MinBIC, CVSegSelect, MinCVmse, MinCV1se
 
 
 ## HELPERS FOR SPARSE COEFFICIENTS
@@ -626,5 +628,6 @@ end
 include("coordinate_descent.jl")
 include("gammalasso.jl")
 include("cross_validation.jl")
+include("segselect.jl")
 
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,59 @@
+import Base: @deprecate
+
+"""
+    coef(path::RegularizationPath; select=:AICc)
+
+Returns a p by nλ coefficient array where p is the number of
+coefficients (including any intercept) and nλ is the number of path segments,
+or a selected segment's coefficients.
+
+If model was only initialized but not fit, returns a p vector of zeros.
+Consistent with StatsBase.coef, if the model has an intercept it is included.
+
+# Example:
+```julia
+  m = fit(LassoPath,X,y)
+  coef(m; select=:CVmin)
+```
+
+# Keywords
+- `select=:all` returns a p by nλ matrix of coefficients
+- `select=:AIC` selects the AIC minimizing segment
+- `select=:AICc` selects the corrected AIC minimizing segment
+- `select=:BIC` selects the BIC minimizing segment
+- `select=:CVmin` selects the segment that minimizing out-of-sample mean squared
+    error from cross-validation with `nCVfolds` random folds.
+- `select=:CV1se` selects the segment whose average OOS deviance is no more than
+    1 standard error away from the one minimizing out-of-sample mean squared
+    error from cross-validation with `nCVfolds` random folds.
+- `nCVfolds=10` number of cross-validation folds
+- `kwargs...` are passed to [`minAICc(::RegularizationPath)`](@ref) or to
+    [`cross_validate_path(::RegularizationPath)`](@ref)
+"""
+function StatsBase.coef(path::RegularizationPath, select::Symbol; nCVfolds=10)
+    if select == :all
+        selector = AllSeg()
+        msg = "AllSeg()"
+    elseif select == :AIC
+        selector = MinAIC()
+        msg = "MinAIC()"
+    elseif select == :AICc
+        selector = MinAICc()
+        msg = "MinAICc()"
+    elseif select == :BIC
+        selector = MinBIC()
+        msg = "MinBIC()"
+    elseif select == :CVmin
+        selector = MinCVmse(path, nCVfolds)
+        msg = "MinCVmse(path, nCVfolds)"
+    elseif select == :CV1se
+        selector = MinCV1se(path, nCVfolds)
+        msg = "MinCV1se(path, nCVfolds)"
+    else
+        error("unknown selector $select")
+    end
+
+    Base.depwarn("coef(path; select::Symbol=:$select) is deprecated, use coef(path, $msg) instead", :coef)
+
+    coef(path, selector)
+end

--- a/src/gammalasso.jl
+++ b/src/gammalasso.jl
@@ -44,6 +44,14 @@ function computeω!(ω::Vector{T}, γ::Vector{T}, penalty_factor::Union{Nothing,
 end
 poststep(path::GammaLassoPath, cd::CoordinateDescent, i::Int, coefs::SparseCoefficients) = computeω!(cd.ω, path.γ, path.penalty_factor, coefs)
 
+"""
+    fit(GammaLassoPath, X, y, d=Normal(), l=canonicallink(d); ...)   
+    
+fits a linear or generalized linear (concave) gamma lasso path given the design
+matrix `X` and response `y`.
+
+See also [`fit(LassoPath...)`](@ref) for a full list of arguments
+"""
 function StatsBase.fit(::Type{GammaLassoPath},
                        X::AbstractMatrix{T}, y::V, d::UnivariateDistribution=Normal(),
                        l::Link=canonicallink(d);

--- a/src/segselect.jl
+++ b/src/segselect.jl
@@ -52,7 +52,30 @@ end
 
 CVfun(oosdevs, ::MinCV1se) = CV1se(oosdevs)
 
+"""
+    coef(path::RegularizationPath; kwargs...)
+    
+Coefficient vector for a selected segment of a regularization path.
+
+# Examples
+```julia
+coef(path; select=MinBIC())     # BIC minimizing segment
+coef(path; select=AllSeg())     # Array with entire path's coefficents
+```
+"""
 StatsBase.coef(path::RegularizationPath; select=AllSeg(), kwargs...) = coef(path, select; kwargs...)
+
+"""
+    coef(path::RegularizationPath, select::SegSelect)
+    
+Coefficient vector for a selected segment of a regularization path.
+
+# Examples
+```julia
+coef(path, MinBIC())     # BIC minimizing segment
+coef(path, AllSeg())     # Array with entire path's coefficents
+```
+"""
 function StatsBase.coef(path::RegularizationPath, select::S) where S <: SegSelect
     if !isdefined(path,:coefs)
         X = path.m.pp.X
@@ -105,6 +128,18 @@ abstract type GammaLassoModel <: RegularizedModel end
 pathtype(::Type{LassoModel}) = LassoPath
 pathtype(::Type{GammaLassoModel}) = GammaLassoPath
 
+"""
+    selectmodel(path::RegularizationPath, select::SegSelect)
+    
+Returns a LinearModel or GeneralizedLinearModel representing the selected 
+segment of a regularization path.
+
+# Examples
+```julia
+selectmodel(path, MinBIC())            # BIC minimizing model
+selectmodel(path, MinCVmse(path, 5))   # 5-fold CV mse minimizing model
+```
+"""
 function selectmodel(path::R, select::SegSelect) where R<:RegularizationPath
     # extract reusable path parts
     m = path.m
@@ -126,6 +161,75 @@ function selectmodel(path::R, select::SegSelect) where R<:RegularizationPath
     newglm(m, segpp)
 end
 
+"""
+    fit(RegularizedModel, X, y, dist, link; <kwargs>)
+    
+Returns a LinearModel or GeneralizedLinearModel representing the selected 
+segment of a regularization path.
+
+# Examples
+```julia
+fit(LassoModel, X, y; select=MinBIC()) # BIC minimizing LinearModel 
+fit(LassoModel, X, y, Binomial(), Logit(); 
+    select=MinCVmse(path, 5)) # 5-fold CV mse minimizing model
+```
+# Arguments
+- `select::SegSelect=MinAICc()`: segment selector.
+- `wts=ones(length(y))`: Weights for each observation                                    
+- `offset=zeros(length(y))`: Offset of each observation                                    
+- `λ`: can be used to specify a specific set of λ values at which models are fit. 
+    If λ is unspecified, Lasso.jl selects nλ logarithmically spaced λ values from
+    `λmax`, the smallest λ value yielding a null model, to
+    `λminratio * λmax`.
+- `nλ=100` number of λ values to use
+- `λminratio=1e-4` if more observations than predictors otherwise 0.001.
+- `stopearly=true`: When `true`, if the proportion of deviance explained 
+    exceeds 0.999 or the difference between the deviance explained by successive λ
+    values falls below `1e-5`, the path stops early.                                    
+- `standardize=true`: Whether to standardize predictors to unit standard deviation 
+    before fitting.                              
+- `intercept=true`: Whether to fit an (unpenalized) model intercept.
+- `algorithm`: Algorithm to use. 
+    `NaiveCoordinateDescent` iteratively computes the dot product of the 
+    predictors with the  residuals, as opposed to the         
+    `CovarianceCoordinateDescent` algorithm, which uses a precomputed Gram matrix.                
+    `NaiveCoordinateDescent` is typically faster when there are many  
+    predictors that will not enter the model or when fitting        
+    generalized linear models.                                      
+    By default uses `NaiveCoordinateDescent` if more than 5x as many predictors 
+    as observations or model is a GLM. `CovarianceCoordinateDescent` otherwise.
+- `randomize=true`: Whether to randomize the order in which coefficients are
+    updated by coordinate descent. This can drastically speed
+    convergence if coefficients are highly correlated.
+- `maxncoef=min(size(X, 2), 2*size(X, 1))`: maximum number of coefficients 
+    allowed in the model. If exceeded, an error will be thrown.
+- `dofit=true`: Whether to fit the model upon construction. If `false`, the 
+    model can be fit later by calling `fit!(model)`.
+- `cd_tol=1e-7`: The tolerance for coordinate descent iterations iterations in
+    the inner loop.
+- `irls_tol=1e-7`: The tolerance for outer iteratively reweighted least squares
+    iterations. This is ignored unless the model is a generalized linear model.
+- `criterion=:coef` Convergence criterion. Controls how ``cd_tol`` and ``irls_tol``
+    are to be interpreted. Possible values are:
+    - ``:coef``: The model is considered to have converged if the
+    the maximum absolute squared difference in coefficients
+    between successive iterations drops below the specified
+    tolerance. This is the criterion used by glmnet.
+    - ``:obj``: The model is considered to have converged if the
+    the relative change in the Lasso/Elastic Net objective
+    between successive iterations drops below the specified
+    tolerance. This is the criterion used by GLM.jl.
+- `minStepFac=0.001`: The minimum step fraction for backtracking line search.
+- `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\\omega_j`` 
+    for each coefficient ``j``, i.e. instead of ``\\lambda`` penalties become
+    ``\\lambda\\omega_j``.
+    Note the penalty factors are internally rescaled to sum to
+    the number of variables (`glmnet.R` convention).
+- `standardizeω=true`: Whether to scale penalty factors to sum to the number of
+    variables (glmnet.R convention).
+
+See also [`fit(::RegularizationPath...)`](@ref) for a full list of arguments
+"""
 function StatsBase.fit(::Type{R}, args...;
     select::SegSelect=MinAICc(), kwargs...) where R<:RegularizedModel
 

--- a/src/segselect.jl
+++ b/src/segselect.jl
@@ -1,0 +1,173 @@
+"RegularizationPath segment selector supertype"
+abstract type SegSelect end
+
+"A RegularizationPath segment selector that returns all segments"
+struct AllSeg <: SegSelect end
+
+"Selects the RegularizationPath segment with the minimum AIC"
+struct MinAIC <: SegSelect end
+
+"Index of the selected RegularizationPath segment"
+segselect(path::RegularizationPath, select::MinAIC) = minAIC(path)
+
+"Selects the RegularizationPath segment with the minimum corrected AIC"
+struct MinAICc <: SegSelect
+    k::Int # k parameter used to correct AIC criterion
+    MinAICc(k::Int=2) = new(k)
+end
+segselect(path::RegularizationPath, select::MinAICc) = minAICc(path; k=select.k)
+
+"Selects the RegularizationPath segment with the minimum BIC"
+struct MinBIC <: SegSelect end
+
+segselect(path::RegularizationPath, select::MinBIC) = minBIC(path)
+
+"RegularizationPath segment selector supertype"
+abstract type CVSegSelect <: SegSelect end
+
+"Selects the RegularizationPath segment with the minimum cross-validation mse"
+struct MinCVmse <: CVSegSelect
+    gen::CrossValGenerator
+
+    MinCVmse(gen::CrossValGenerator) = new(gen)
+    MinCVmse(path::RegularizationPath, k::Int=10) = new(Kfold(length(path.m.rr.y), k))
+end
+
+CVfun(oosdevs, ::MinCVmse) = CVmin(oosdevs)
+
+"""
+Selects the RegularizationPath segment with the largest λt with mean
+OOS deviance no more than one standard error away from minimum
+"""
+struct MinCV1se <: CVSegSelect
+    gen::CrossValGenerator
+
+    MinCV1se(gen::CrossValGenerator) = new(gen)
+    MinCV1se(path::RegularizationPath, k::Int=10) = new(Kfold(length(path.m.rr.y), k))
+end
+
+CVfun(oosdevs, ::MinCV1se) = CV1se(oosdevs)
+
+StatsBase.coef(path::RegularizationPath; select::S=AllSeg()) where S <: SegSelect = coef(path, select)
+function StatsBase.coef(path::RegularizationPath, select::S) where S <: SegSelect
+    if !isdefined(path,:coefs)
+        X = path.m.pp.X
+        p,nλ = size(path)
+        return zeros(eltype(X),p)
+    end
+
+    seg = segselect(path, select)
+
+    if hasintercept(path)
+        vec(vcat(path.b0[seg],path.coefs[:,seg]))
+    else
+        path.coefs[:,seg]
+    end
+end
+
+function StatsBase.coef(path::RegularizationPath, select::AllSeg)
+    if !isdefined(path,:coefs)
+        X = path.m.pp.X
+        p,nλ = size(path)
+        return spzeros(eltype(X),p,nλ)
+    end
+
+    if hasintercept(path)
+        vcat(path.b0',path.coefs)
+    else
+        path.coefs
+    end
+end
+
+function cross_validate_path(path::RegularizationPath,    # fitted path
+                       X::AbstractMatrix{T}, y::V,        # potentially new data
+                       select::S;
+                       offset::FPVector=T[],
+                       fitargs...) where {T<:AbstractFloat,V<:FPVector, S<:CVSegSelect}
+    @extractfields path m λ
+    gen = select.gen
+    n,p = size(X)
+    @assert n == length(y) "size(X,1) != length(y)"
+
+    nfolds = length(gen)
+    nλ = length(λ)
+    d = distfun(path)
+    l = linkfun(path)
+
+    # valid offset given?
+    if length(m.rr.offset) > 0
+        length(offset) == n ||
+            throw(ArgumentError("fit with offset, so `offset` kw arg must be an offset of length $n"))
+    else
+        length(offset) > 0 && throw(ArgumentError("fit without offset, so value of `offset` kw arg does not make sense"))
+    end
+
+    # EQUAL WEIGHTS ONLY!
+    wts = ones(T, n)
+
+    # results array
+    oosdevs = zeros(T,nλ,nfolds)
+
+    for (f, train_inds) in enumerate(gen)
+        test_inds = setdiff(1:n, train_inds)
+        nis = length(test_inds)
+
+        if length(offset) > 0
+            foldoffset = offset[train_inds]
+        else
+            foldoffset = offset
+        end
+
+        # fit model to train_inds
+        foldpath = fit(pathtype(path),X[train_inds,:],y[train_inds],d,l;λ=λ,wts=wts[train_inds],offset=foldoffset,fitargs...)
+
+        if length(offset) > 0
+            foldoffset = offset[test_inds]
+        else
+            foldoffset = offset
+        end
+
+        # calculate etas for each obs x segment
+        μ = predict(foldpath, X[test_inds,:]; offset=foldoffset, select=select)
+
+        # calculate deviations on test sets efficiently (not much mem)
+        for s=1:nλ
+            # deviance of segment s (cummulator for sum of obs deviances)
+            devs = zero(T)
+
+            for ip=1:nis
+                # get test obs
+                yi = y[test_inds[ip]]
+
+                # deviance of a single observation i in segment s
+                devs += devresid(d, yi, μ[ip,s])
+            end
+
+            # store result
+            oosdevs[s,f] = devs/nis
+        end
+    end
+
+    CVfun(oosdevs, select)
+end
+
+# convenience function to use the same data as in original path
+function cross_validate_path(path::RegularizationPath,     # fitted path
+                        select::S;
+                        fitargs...) where S<:CVSegSelect
+    m = path.m
+    y = m.rr.y
+    offset = m.rr.offset
+    Xstandardized = m.pp.X
+    cross_validate_path(path,Xstandardized,y,select;
+        offset=offset,standardize=false,fitargs...)
+end
+
+segselect(path::RegularizationPath, select::S) where S<:CVSegSelect =
+    cross_validate_path(path, select)
+
+segselect(path::RegularizationPath,
+           X::AbstractMatrix{T}, y::V,        # potentially new data
+           select::S;
+           kwargs...) where {T<:AbstractFloat,V<:FPVector, S<:CVSegSelect} =
+    cross_validate_path(path, X, y, select; kwargs...)

--- a/test/cross_validation.jl
+++ b/test/cross_validation.jl
@@ -10,40 +10,41 @@ X = data[:,2:end]
 offset = fill(0.001,size(y))
 
 path = fit(LassoPath, X, y; offset=offset)
-β = coef(path; select=:all)
+β = coef(path, AllSeg())
 
-coefsAICc = coef(path;select=:AICc)
+coefsAICc = coef(path, MinAICc())
 segminAICc = minAICc(path)
 @test segminAICc == 71
 @test coefsAICc == β[:,segminAICc]
 
-coefsBIC = coef(path;select=:BIC)
+coefsBIC = coef(path, MinBIC())
 segminBIC = Lasso.minBIC(path)
 @test segminBIC == 55
 @test coefsBIC == β[:,segminBIC]
 
-coefsAIC = coef(path;select=:AIC)
+coefsAIC = coef(path, MinAIC())
 segminAIC = Lasso.minAIC(path)
 @test segminAIC == 71
 @test coefsAIC == β[:,segminAIC]
 
 Random.seed!(13)
 gen = Kfold(length(y),10)
-segCVmin = cross_validate_path(path;gen=gen)
-coefsCVmin = coef(path;select=:CVmin)
+segCVmin = cross_validate_path(path,MinCVmse(gen))
+coefsCVmin = coef(path, MinCVmse(path))
 @test segCVmin == 71
 @test coefsCVmin == β[:,segCVmin]
 
 Random.seed!(13)
 gen = Kfold(length(y),10)
-segCVmin = cross_validate_path(path,X,y; gen=gen, offset=offset)
-coefsCVmin = coef(path;select=:CVmin)
+segCVmin = cross_validate_path(path,X,y, MinCVmse(gen), offset=offset)
+coefsCVmin = coef(path, MinCVmse(path))
 @test segCVmin == 71
 @test coefsCVmin == β[:,segCVmin]
 
 Random.seed!(13)
-coefsCV1se = coef(path;select=:CV1se,nCVfolds=20)
-segCV1se = cross_validate_path(path,X,y;select=:CV1se,gen=gen,offset=offset)
+coefsCV1se = coef(path, MinCV1se(path, 20))
+Random.seed!(13)
+segCV1se = cross_validate_path(path,X,y, MinCV1se(path, 20),offset=offset)
 @test segCV1se == 42
 @test coefsCV1se == β[:,segCV1se]
 

--- a/test/gammalasso.jl
+++ b/test/gammalasso.jl
@@ -72,8 +72,8 @@ Random.seed!(243214)
                 gcoefs_CVmin = vec(readcsvmat(joinpath(datapath,"gamlr.$family.$fitname.coefs.CVmin.csv")))
                 gcoefs_CV1se = vec(readcsvmat(joinpath(datapath,"gamlr.$family.$fitname.coefs.CV1se.csv")))
 
-                glp_CVmin = coef(glp,select=:CVmin,nCVfolds=10)
-                glp_CV1se = coef(glp,select=:CV1se,nCVfolds=10)
+                glp_CVmin = coef(glp,MinCVmse(glp, 10))
+                glp_CV1se = coef(glp,MinCV1se(glp, 10))
 
                 @test glp_CVmin ≈ gcoefs_CVmin rtol=0.3
                 @test glp_CV1se ≈ gcoefs_CV1se rtol=0.3
@@ -96,103 +96,105 @@ end
 # rdist(x::Number,y::Number) = abs(x-y)/max(abs(x),abs(y))
 # rdist(x::AbstractArray{T}, y::AbstractArray{S}; norm::Function=norm) where {T<:Number,S<:Number} = norm(x - y) / max(norm(x), norm(y))
 
-(family, dist, link) = (("gaussian", Normal(), IdentityLink()), ("binomial", Binomial(), LogitLink()), ("poisson", Poisson(), LogLink()))[2]
-data = readcsvmat(joinpath(datapath,"gamlr.$family.data.csv"))
-y = convert(Vector{Float64},data[:,1])
-X = convert(Matrix{Float64},data[:,2:end])
-(n,p) = size(X)
-pf = (1:size(penaltyfactors,2))[1]
-penalty_factor = penaltyfactors[:,pf]
-if penalty_factor == ones(p)
-    penalty_factor = nothing
-end
-
-γ = [0 2 10][1]
-fitname = "gamma$γ.pf$pf"
-
-# get gamlr.R prms and estimates
-prms = CSV.read(joinpath(datapath,"gamlr.$family.$fitname.params.csv"))
-fittable = CSV.read(joinpath(datapath,"gamlr.$family.$fitname.fit.csv"))
-gcoefs = readcsvmat(joinpath(datapath,"gamlr.$family.$fitname.coefs.csv");types=[Float64 for i=1:100])
-family = prms[1,Symbol("fit.family")]
-γ = prms[1,Symbol("fit.gamma")]
-λ = nothing #convert(Vector{Float64},fittable[Symbol("fit.lambda")]) # should be set to nothing evenatually
-
-# fit julia version
-glp = fit(GammaLassoPath, X, y, dist, link; γ=γ, stopearly=false,
-    λminratio=0.001, penalty_factor=penalty_factor, λ=λ,
-    standardize=false, standardizeω=false)
-
-using InteractiveUtils, BenchmarkTools
-@code_warntype coef(glp; select=:all)
-@code_warntype minAICc(glp)
-@code_warntype segselect(glp, Lasso.MinAIC())
-
-@code_warntype coef(glp)
-@code_warntype coef(glp, AllSeg())
-@code_warntype coef(glp; select=:AICc)
-@code_warntype coef(glp, MinAICc())
-
-@btime coef(glp)
-s = AllSeg()
-@btime coef(glp, s)
-@btime coef(glp; select=:AICc)
-@btime (s = MinAICc())
-s = MinAICc()
-@btime coef(glp, s)
-
-m = fit(Lasso, X, y, dist, link; stopearly=false,
-    λminratio=0.001, penalty_factor=penalty_factor, λ=λ,
-    standardize=false, standardizeω=false)
-show(coef(m))
-predict(m)
-
-γ = 1
-m = fit(GammaLasso, X, y, dist, link; γ=γ, stopearly=false,
-    λminratio=0.001, penalty_factor=penalty_factor, λ=λ,
-    standardize=false, standardizeω=false)
-show(coef(m))
-predict(m)
-
-# compare
-@test true==issimilarhead(glp.λ,fittable[Symbol("fit.lambda")];rtol=rtol)
-@test true==issimilarhead(glp.b0,fittable[Symbol("fit.alpha")];rtol=rtol)
-@test true==issimilarhead(convert(Matrix{Float64},glp.coefs'),gcoefs';rtol=rtol)
-# we follow GLM.jl convention where deviance is scaled by nobs, while in gamlr it is not
-@test true==issimilarhead(deviance(glp),fittable[Symbol("fit.deviance")]/nobs(glp);rtol=rtol)
-@test true==issimilarhead(deviance(glp,X,y),fittable[Symbol("fit.deviance")]/nobs(glp);rtol=rtol)
-# @test true==issimilarhead(round(df(glp)[2:end]),round(fittable[2:end,Symbol("fit.df")]))
-@test true==issimilarhead(loglikelihood(glp),fittable[Symbol("fit.logLik")];rtol=rtol)
-@test true==issimilarhead(aicc(glp),fittable[Symbol("fit.AICc")];rtol=rtol)
-
-# TODO: figure out why these are so off, maybe because most are corner solutions
-# and stopping rules for lambda are different
-# # what we really need all these stats for is that the AICc identifies the same minima:
-# if argmin(aicc(glp)) != lastindex(aicc(glp)) && argmin(fittable[Symbol("fit.AICc")]) != lastindex(fittable[Symbol("fit.AICc")])
-#     # interior minima
-#     println("comparing intereior AICc")
-#     @test argmin(aicc(glp)) == argmin(fittable[Symbol("fit.AICc")])
+# (family, dist, link) = (("gaussian", Normal(), IdentityLink()), ("binomial", Binomial(), LogitLink()), ("poisson", Poisson(), LogLink()))[2]
+# data = readcsvmat(joinpath(datapath,"gamlr.$family.data.csv"))
+# y = convert(Vector{Float64},data[:,1])
+# X = convert(Matrix{Float64},data[:,2:end])
+# (n,p) = size(X)
+# pf = (1:size(penaltyfactors,2))[1]
+# penalty_factor = penaltyfactors[:,pf]
+# if penalty_factor == ones(p)
+#     penalty_factor = nothing
 # end
-
-# comparse CV, NOTE: this involves a random choice of train subsamples
-gcoefs_CVmin = vec(readcsvmat(joinpath(datapath,"gamlr.$family.$fitname.coefs.CVmin.csv")))
-gcoefs_CV1se = vec(readcsvmat(joinpath(datapath,"gamlr.$family.$fitname.coefs.CV1se.csv")))
-
-@btime coef(glp,select=:CVmin,nCVfolds=10)
-coef(glp, MinCVmse(glp, 10))
-glp_CVmin = coef(glp,select=:CVmin,nCVfolds=10)
-
-glp_CV1se = coef(glp,select=:CV1se,nCVfolds=10)
-
-@test glp_CVmin ≈ gcoefs_CVmin rtol=0.3
-@test glp_CV1se ≈ gcoefs_CV1se rtol=0.3
-
-if γ==0
-    # Compare with LassoPath
-    lp = fit(LassoPath, X, y, dist, link; stopearly=false,
-        λminratio=0.001, penalty_factor=penalty_factor, λ=λ,
-        standardize=false, standardizeω=false)
-    @test glp.λ == lp.λ
-    @test glp.b0 ≈ lp.b0
-    @test glp.coefs ≈ lp.coefs
-end
+#
+# γ = [0 2 10][1]
+# fitname = "gamma$γ.pf$pf"
+#
+# # get gamlr.R prms and estimates
+# prms = CSV.read(joinpath(datapath,"gamlr.$family.$fitname.params.csv"))
+# fittable = CSV.read(joinpath(datapath,"gamlr.$family.$fitname.fit.csv"))
+# gcoefs = readcsvmat(joinpath(datapath,"gamlr.$family.$fitname.coefs.csv");types=[Float64 for i=1:100])
+# family = prms[1,Symbol("fit.family")]
+# γ = prms[1,Symbol("fit.gamma")]
+# λ = nothing #convert(Vector{Float64},fittable[Symbol("fit.lambda")]) # should be set to nothing evenatually
+#
+# # fit julia version
+# glp = fit(GammaLassoPath, X, y, dist, link; γ=γ, stopearly=false,
+#     λminratio=0.001, penalty_factor=penalty_factor, λ=λ,
+#     standardize=false, standardizeω=false)
+#
+# using InteractiveUtils, BenchmarkTools
+# @code_warntype coef(glp; select=:all)
+# @code_warntype minAICc(glp)
+# @code_warntype segselect(glp, Lasso.MinAIC())
+#
+# @code_warntype coef(glp)
+# @code_warntype coef(glp, AllSeg())
+# @code_warntype coef(glp; select=:AICc)
+# @code_warntype coef(glp, MinAICc())
+#
+# @btime coef(glp)
+# s = AllSeg()
+# @btime coef(glp, s)
+# coef(glp; select=:AICc)
+# @btime coef(glp; select=:AICc)
+# @btime (s = MinAICc())
+# s = MinAICc()
+# @btime coef(glp, s)
+#
+# m = fit(LassoModel, X, y, dist, link; stopearly=false,
+#     λminratio=0.001, penalty_factor=penalty_factor, λ=λ,
+#     standardize=false, standardizeω=false)
+# show(coef(m))
+# predict(m)
+#
+# γ = 1
+# m = fit(GammaLassoModel, X, y, dist, link; γ=γ, stopearly=false,
+#     λminratio=0.001, penalty_factor=penalty_factor, λ=λ,
+#     standardize=false, standardizeω=false)
+# show(coef(m))
+# predict(m)
+#
+# # compare
+# @test true==issimilarhead(glp.λ,fittable[Symbol("fit.lambda")];rtol=rtol)
+# @test true==issimilarhead(glp.b0,fittable[Symbol("fit.alpha")];rtol=rtol)
+# @test true==issimilarhead(convert(Matrix{Float64},glp.coefs'),gcoefs';rtol=rtol)
+# # we follow GLM.jl convention where deviance is scaled by nobs, while in gamlr it is not
+# @test true==issimilarhead(deviance(glp),fittable[Symbol("fit.deviance")]/nobs(glp);rtol=rtol)
+# @test true==issimilarhead(deviance(glp,X,y),fittable[Symbol("fit.deviance")]/nobs(glp);rtol=rtol)
+# # @test true==issimilarhead(round(df(glp)[2:end]),round(fittable[2:end,Symbol("fit.df")]))
+# @test true==issimilarhead(loglikelihood(glp),fittable[Symbol("fit.logLik")];rtol=rtol)
+# @test true==issimilarhead(aicc(glp),fittable[Symbol("fit.AICc")];rtol=rtol)
+#
+# # TODO: figure out why these are so off, maybe because most are corner solutions
+# # and stopping rules for lambda are different
+# # # what we really need all these stats for is that the AICc identifies the same minima:
+# # if argmin(aicc(glp)) != lastindex(aicc(glp)) && argmin(fittable[Symbol("fit.AICc")]) != lastindex(fittable[Symbol("fit.AICc")])
+# #     # interior minima
+# #     println("comparing intereior AICc")
+# #     @test argmin(aicc(glp)) == argmin(fittable[Symbol("fit.AICc")])
+# # end
+#
+# # comparse CV, NOTE: this involves a random choice of train subsamples
+# gcoefs_CVmin = vec(readcsvmat(joinpath(datapath,"gamlr.$family.$fitname.coefs.CVmin.csv")))
+# gcoefs_CV1se = vec(readcsvmat(joinpath(datapath,"gamlr.$family.$fitname.coefs.CV1se.csv")))
+#
+# @btime coef(glp,select=:CVmin,nCVfolds=10)
+# @btime coef(glp, MinCVmse(glp, 10))
+# @btime coef(glp, MinCV1se(glp, 10))
+# glp_CVmin = coef(glp,select=:CVmin,nCVfolds=10)
+#
+# glp_CV1se = coef(glp,select=:CV1se,nCVfolds=10)
+#
+# @test glp_CVmin ≈ gcoefs_CVmin rtol=0.3
+# @test glp_CV1se ≈ gcoefs_CV1se rtol=0.3
+#
+# if γ==0
+#     # Compare with LassoPath
+#     lp = fit(LassoPath, X, y, dist, link; stopearly=false,
+#         λminratio=0.001, penalty_factor=penalty_factor, λ=λ,
+#         standardize=false, standardizeω=false)
+#     @test glp.λ == lp.λ
+#     @test glp.b0 ≈ lp.b0
+#     @test glp.coefs ≈ lp.coefs
+# end

--- a/test/gammalasso.jl
+++ b/test/gammalasso.jl
@@ -95,3 +95,91 @@ end
 #
 # rdist(x::Number,y::Number) = abs(x-y)/max(abs(x),abs(y))
 # rdist(x::AbstractArray{T}, y::AbstractArray{S}; norm::Function=norm) where {T<:Number,S<:Number} = norm(x - y) / max(norm(x), norm(y))
+
+(family, dist, link) = (("gaussian", Normal(), IdentityLink()), ("binomial", Binomial(), LogitLink()), ("poisson", Poisson(), LogLink()))[1]
+data = readcsvmat(joinpath(datapath,"gamlr.$family.data.csv"))
+y = convert(Vector{Float64},data[:,1])
+X = convert(Matrix{Float64},data[:,2:end])
+(n,p) = size(X)
+pf = (1:size(penaltyfactors,2))[1]
+penalty_factor = penaltyfactors[:,pf]
+if penalty_factor == ones(p)
+    penalty_factor = nothing
+end
+
+γ = [0 2 10][1]
+fitname = "gamma$γ.pf$pf"
+
+# get gamlr.R prms and estimates
+prms = CSV.read(joinpath(datapath,"gamlr.$family.$fitname.params.csv"))
+fittable = CSV.read(joinpath(datapath,"gamlr.$family.$fitname.fit.csv"))
+gcoefs = readcsvmat(joinpath(datapath,"gamlr.$family.$fitname.coefs.csv");types=[Float64 for i=1:100])
+family = prms[1,Symbol("fit.family")]
+γ = prms[1,Symbol("fit.gamma")]
+λ = nothing #convert(Vector{Float64},fittable[Symbol("fit.lambda")]) # should be set to nothing evenatually
+
+# fit julia version
+glp = fit(GammaLassoPath, X, y, dist, link; γ=γ, stopearly=false,
+    λminratio=0.001, penalty_factor=penalty_factor, λ=λ,
+    standardize=false, standardizeω=false)
+
+using InteractiveUtils, BenchmarkTools
+@code_warntype coef(glp; select=:all)
+@code_warntype minAICc(glp)
+@code_warntype segselect(glp, Lasso.MinAIC())
+
+@code_warntype coef(glp)
+@code_warntype coef(glp, AllSeg())
+@code_warntype coef(glp; select=:AICc)
+@code_warntype coef(glp, MinAICc())
+
+@btime coef(glp)
+@btime (s = AllSeg())
+@btime coef(glp, s)
+@btime coef(glp; select=:AICc)
+@btime (s = MinAICc())
+s = MinAICc()
+@btime coef(glp, s)
+
+# compare
+@test true==issimilarhead(glp.λ,fittable[Symbol("fit.lambda")];rtol=rtol)
+@test true==issimilarhead(glp.b0,fittable[Symbol("fit.alpha")];rtol=rtol)
+@test true==issimilarhead(convert(Matrix{Float64},glp.coefs'),gcoefs';rtol=rtol)
+# we follow GLM.jl convention where deviance is scaled by nobs, while in gamlr it is not
+@test true==issimilarhead(deviance(glp),fittable[Symbol("fit.deviance")]/nobs(glp);rtol=rtol)
+@test true==issimilarhead(deviance(glp,X,y),fittable[Symbol("fit.deviance")]/nobs(glp);rtol=rtol)
+# @test true==issimilarhead(round(df(glp)[2:end]),round(fittable[2:end,Symbol("fit.df")]))
+@test true==issimilarhead(loglikelihood(glp),fittable[Symbol("fit.logLik")];rtol=rtol)
+@test true==issimilarhead(aicc(glp),fittable[Symbol("fit.AICc")];rtol=rtol)
+
+# TODO: figure out why these are so off, maybe because most are corner solutions
+# and stopping rules for lambda are different
+# # what we really need all these stats for is that the AICc identifies the same minima:
+# if argmin(aicc(glp)) != lastindex(aicc(glp)) && argmin(fittable[Symbol("fit.AICc")]) != lastindex(fittable[Symbol("fit.AICc")])
+#     # interior minima
+#     println("comparing intereior AICc")
+#     @test argmin(aicc(glp)) == argmin(fittable[Symbol("fit.AICc")])
+# end
+
+# comparse CV, NOTE: this involves a random choice of train subsamples
+gcoefs_CVmin = vec(readcsvmat(joinpath(datapath,"gamlr.$family.$fitname.coefs.CVmin.csv")))
+gcoefs_CV1se = vec(readcsvmat(joinpath(datapath,"gamlr.$family.$fitname.coefs.CV1se.csv")))
+
+@btime coef(glp,select=:CVmin,nCVfolds=10)
+coef(glp, MinCVmse(glp, 10))
+glp_CVmin = coef(glp,select=:CVmin,nCVfolds=10)
+
+glp_CV1se = coef(glp,select=:CV1se,nCVfolds=10)
+
+@test glp_CVmin ≈ gcoefs_CVmin rtol=0.3
+@test glp_CV1se ≈ gcoefs_CV1se rtol=0.3
+
+if γ==0
+    # Compare with LassoPath
+    lp = fit(LassoPath, X, y, dist, link; stopearly=false,
+        λminratio=0.001, penalty_factor=penalty_factor, λ=λ,
+        standardize=false, standardizeω=false)
+    @test glp.λ == lp.λ
+    @test glp.b0 ≈ lp.b0
+    @test glp.coefs ≈ lp.coefs
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test
+using Test, Lasso
 
 using CSV
 readcsvmat(path;header=false, kwargs...) = convert(Matrix{Float64},CSV.read(path;header=header, kwargs...))
@@ -10,5 +10,6 @@ include("gammalasso.jl")
 include("fusedlasso.jl")
 include("trendfiltering.jl")
 include("cross_validation.jl")
+include("segselect.jl")
 
 end

--- a/test/segselect.jl
+++ b/test/segselect.jl
@@ -1,0 +1,37 @@
+using Random
+@testset "segment/model selection" begin
+
+datapath = joinpath(dirname(@__FILE__), "data")
+
+@testset "$family" for (family, dist, link) in (("gaussian", Normal(), IdentityLink()), ("binomial", Binomial(), LogitLink()), ("poisson", Poisson(), LogLink()))
+    data = readcsvmat(joinpath(datapath,"gamlr.$family.data.csv"))
+    y = convert(Vector{Float64},data[:,1])
+    X = convert(Matrix{Float64},data[:,2:end])
+    Xwconst = [ones(size(X,1),1) X]
+    offset = fill(0.001,size(y))
+
+    @testset "$L" for L in [LassoModel, GammaLassoModel]
+        R = Lasso.pathtype(L)
+        path = fit(R, X, y, dist, link; offset=offset)
+
+        @testset "$(typeof(select))" for select in [MinAIC(), MinAICc(), MinBIC(), MinCVmse(path), MinCV1se(path)]
+            Random.seed!(421)
+            m = fit(L, X, y, dist, link; select=select, offset=offset);
+
+            Random.seed!(421)
+            pathcoefs = coef(path, select)
+
+            Random.seed!(421)
+            pathpredict = Lasso.predict(path, X; select=select, offset=offset)
+
+            @test pathcoefs == coef(m)
+            if isa(m, LinearModel)
+                @test pathpredict == GLM.predict(m, Xwconst) + offset
+            else
+                @test pathpredict == GLM.predict(m, Xwconst; offset=offset)
+            end
+        end
+    end
+end
+
+end


### PR DESCRIPTION
The current approach to selecting a regularization path segment is using the `select::Symbol` keyword argument as in `coef(path; select=:AIC)` or `predict(path, newX; select=:AIC)`.
Because one of the possibilities is to select coefficients from all segments with `select=:all` (the default), these methods are not type safe.

This PR deprecates these methods, and replaces them with similar methods that take a path and a `SegSelect` struct, which takes care of the logic of selecting a particular segment.
It implements `MinAIC`, `MinAICc`, `MinBIC`, `MinCVmse`, and `MinCV1se` segment selectors, and makes it easy to create new ones by defining a new `SegSelect` struct and implementing its `segselect()` method.

This PR also provides a simpler interface for fitting a lasso model and selecting the segment all in one call with a `fit(RegularizedModel, X, y, dist, link; <kwargs>)` method.     
It returns a `LinearModel` or `GeneralizedLinearModel` representing the selected 
segment of a regularization path.

For example,
```julia
fit(LassoModel, X, y; select=MinBIC()) # BIC minimizing LinearModel 
fit(LassoModel, X, y, Binomial(), Logit(); 
    select=MinCVmse(path, 5)) # 5-fold CV mse minimizing model
```

This approach has the advantage that the model can be described (with `coef`) and used for prediction (with `predict`), without rerunning the selector, which can be expensive for cross-validating selectors.