### PR TITLE
fixes fit(LassoPath,@formula,df) interface and adds tests for it

### DIFF
--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -292,7 +292,7 @@ function build_model(X::AbstractMatrix{T}, y::FPVector, d::Normal, l::IdentityLi
                      lp::LinPred, λminratio::Real, λ::Union{Vector,Nothing},
                      wts::Union{FPVector,Nothing}, offset::Vector, α::Real, nλ::Int,
                      ω::Union{Vector,Nothing}, intercept::Bool, irls_tol::Real, dofit::Bool) where T
-    mu = isempty(offset) ? y : y + offset
+    mu = isempty(offset) ? copy(y) : y + offset
     nullmodel = LinearModel(LmResp{typeof(y)}(fill!(similar(y), 0), offset, wts, y),
                             GLM.cholpred(nullX(X, intercept, ω), false))
     fit!(nullmodel)
@@ -355,12 +355,12 @@ function standardizeX(X::AbstractMatrix{T}, standardize::Bool) where T
 end
 
 """
-    fit(LassoPath, X, y, d=Normal(), l=canonicallink(d); ...)   
-    
+    fit(LassoPath, X, y, d=Normal(), l=canonicallink(d); ...)
+
 fits a linear or generalized linear Lasso path given the design
 matrix `X` and response `y`:
 
-``\\underset{\\beta}{\\operatorname{argmin}} -\\frac{1}{N} \\mathcal{L}(y|X,\\beta) 
+``\\underset{\\beta}{\\operatorname{argmin}} -\\frac{1}{N} \\mathcal{L}(y|X,\\beta)
 + \\lambda\\left[(1-\\alpha)\\frac{1}{2}\\|\\beta\\|_2^2 + \\alpha\\|\\beta\\|_1\\right]``
 
 The optional argument `d` specifies the conditional distribution of
@@ -372,40 +372,40 @@ or ``\\mathcal{L}(y|X,\\beta) = -\\frac{1}{2}\\|y - X\\beta\\|_2^2 + C``
 # Examples
 ```julia
 fit(LassoPath, X, y)    # L1-regularized linear regression
-fit(LassoPath, X, y, Binomial(), Logit(); 
-    α=0.5) # Binomial logit regression with an Elastic net combination of 
+fit(LassoPath, X, y, Binomial(), Logit();
+    α=0.5) # Binomial logit regression with an Elastic net combination of
            # 0.5 L1 and 0.5 L2 regularization penalties
 ```
 # Arguments
-- `wts=ones(length(y))`: Weights for each observation                                    
-- `offset=zeros(length(y))`: Offset of each observation                                    
-- `λ`: can be used to specify a specific set of λ values at which models are fit. 
+- `wts=ones(length(y))`: Weights for each observation
+- `offset=zeros(length(y))`: Offset of each observation
+- `λ`: can be used to specify a specific set of λ values at which models are fit.
     If λ is unspecified, Lasso.jl selects nλ logarithmically spaced λ values from
     `λmax`, the smallest λ value yielding a null model, to
     `λminratio * λmax`.
 - `nλ=100` number of λ values to use
 - `λminratio=1e-4` if more observations than predictors otherwise 0.001.
-- `stopearly=true`: When `true`, if the proportion of deviance explained 
+- `stopearly=true`: When `true`, if the proportion of deviance explained
     exceeds 0.999 or the difference between the deviance explained by successive λ
-    values falls below `1e-5`, the path stops early.                                    
-- `standardize=true`: Whether to standardize predictors to unit standard deviation 
-    before fitting.                              
+    values falls below `1e-5`, the path stops early.
+- `standardize=true`: Whether to standardize predictors to unit standard deviation
+    before fitting.
 - `intercept=true`: Whether to fit an (unpenalized) model intercept.
-- `algorithm`: Algorithm to use. 
-    `NaiveCoordinateDescent` iteratively computes the dot product of the 
-    predictors with the  residuals, as opposed to the         
-    `CovarianceCoordinateDescent` algorithm, which uses a precomputed Gram matrix.                
-    `NaiveCoordinateDescent` is typically faster when there are many  
-    predictors that will not enter the model or when fitting        
-    generalized linear models.                                      
-    By default uses `NaiveCoordinateDescent` if more than 5x as many predictors 
+- `algorithm`: Algorithm to use.
+    `NaiveCoordinateDescent` iteratively computes the dot product of the
+    predictors with the  residuals, as opposed to the
+    `CovarianceCoordinateDescent` algorithm, which uses a precomputed Gram matrix.
+    `NaiveCoordinateDescent` is typically faster when there are many
+    predictors that will not enter the model or when fitting
+    generalized linear models.
+    By default uses `NaiveCoordinateDescent` if more than 5x as many predictors
     as observations or model is a GLM. `CovarianceCoordinateDescent` otherwise.
 - `randomize=true`: Whether to randomize the order in which coefficients are
     updated by coordinate descent. This can drastically speed
     convergence if coefficients are highly correlated.
-- `maxncoef=min(size(X, 2), 2*size(X, 1))`: maximum number of coefficients 
+- `maxncoef=min(size(X, 2), 2*size(X, 1))`: maximum number of coefficients
     allowed in the model. If exceeded, an error will be thrown.
-- `dofit=true`: Whether to fit the model upon construction. If `false`, the 
+- `dofit=true`: Whether to fit the model upon construction. If `false`, the
     model can be fit later by calling `fit!(model)`.
 - `cd_tol=1e-7`: The tolerance for coordinate descent iterations iterations in
     the inner loop.
@@ -422,7 +422,7 @@ fit(LassoPath, X, y, Binomial(), Logit();
     between successive iterations drops below the specified
     tolerance. This is the criterion used by GLM.jl.
 - `minStepFac=0.001`: The minimum step fraction for backtracking line search.
-- `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\\omega_j`` 
+- `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\\omega_j``
     for each coefficient ``j``, i.e. instead of ``\\lambda`` penalties become
     ``\\lambda\\omega_j``.
     Note the penalty factors are internally rescaled to sum to

--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -14,7 +14,8 @@ include("TrendFiltering.jl")
 using Reexport, LinearAlgebra, SparseArrays, Random, .Util, MLBase
 import Random: Sampler
 @reexport using GLM, Distributions, .FusedLassoMod, .TrendFiltering
-using GLM: FPVector
+using GLM: FPVector, LinPred, Link, LmResp, GlmResp, DensePredQR, updateμ!,
+    linkfun, linkinv
 export RegularizationPath, LassoPath, GammaLassoPath, NaiveCoordinateDescent,
        CovarianceCoordinateDescent, fit, fit!, coef, predict,
        minAICc, hasintercept, dof, aicc, distfun, linkfun, cross_validate_path,

--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -159,6 +159,10 @@ end
 addcoef(x::UnitRange{Int}, icoef::Int) = 1:length(x)+1
 
 abstract type RegularizationPath{S<:Union{LinearModel,GeneralizedLinearModel},T} <: RegressionModel end
+
+# don't add an intercept when using a @formula because we use the intercept keyword arg to add an intercept
+StatsModels.drop_intercept(::Type{R}) where R<:RegularizationPath = true
+
 ## LASSO PATH
 
 mutable struct LassoPath{S<:Union{LinearModel,GeneralizedLinearModel},T} <: RegularizationPath{S,T}
@@ -350,12 +354,12 @@ function standardizeX(X::AbstractMatrix{T}, standardize::Bool) where T
 end
 
 """
-    fit(LassoPath, X, y, d=Normal(), l=canonicallink(d); ...)   
-    
+    fit(LassoPath, X, y, d=Normal(), l=canonicallink(d); ...)
+
 fits a linear or generalized linear Lasso path given the design
 matrix `X` and response `y`:
 
-``\\underset{\\beta}{\\operatorname{argmin}} -\\frac{1}{N} \\mathcal{L}(y|X,\\beta) 
+``\\underset{\\beta}{\\operatorname{argmin}} -\\frac{1}{N} \\mathcal{L}(y|X,\\beta)
 + \\lambda\\left[(1-\\alpha)\\frac{1}{2}\\|\\beta\\|_2^2 + \\alpha\\|\\beta\\|_1\\right]``
 
 The optional argument `d` specifies the conditional distribution of
@@ -367,40 +371,40 @@ or ``\\mathcal{L}(y|X,\\beta) = -\\frac{1}{2}\\|y - X\\beta\\|_2^2 + C``
 # Examples
 ```julia
 fit(LassoPath, X, y)    # L1-regularized linear regression
-fit(LassoPath, X, y, Binomial(), Logit(); 
-    α=0.5) # Binomial logit regression with an Elastic net combination of 
+fit(LassoPath, X, y, Binomial(), Logit();
+    α=0.5) # Binomial logit regression with an Elastic net combination of
            # 0.5 L1 and 0.5 L2 regularization penalties
 ```
 # Arguments
-- `wts=ones(length(y))`: Weights for each observation                                    
-- `offset=zeros(length(y))`: Offset of each observation                                    
-- `λ`: can be used to specify a specific set of λ values at which models are fit. 
+- `wts=ones(length(y))`: Weights for each observation
+- `offset=zeros(length(y))`: Offset of each observation
+- `λ`: can be used to specify a specific set of λ values at which models are fit.
     If λ is unspecified, Lasso.jl selects nλ logarithmically spaced λ values from
     `λmax`, the smallest λ value yielding a null model, to
     `λminratio * λmax`.
 - `nλ=100` number of λ values to use
 - `λminratio=1e-4` if more observations than predictors otherwise 0.001.
-- `stopearly=true`: When `true`, if the proportion of deviance explained 
+- `stopearly=true`: When `true`, if the proportion of deviance explained
     exceeds 0.999 or the difference between the deviance explained by successive λ
-    values falls below `1e-5`, the path stops early.                                    
-- `standardize=true`: Whether to standardize predictors to unit standard deviation 
-    before fitting.                              
+    values falls below `1e-5`, the path stops early.
+- `standardize=true`: Whether to standardize predictors to unit standard deviation
+    before fitting.
 - `intercept=true`: Whether to fit an (unpenalized) model intercept.
-- `algorithm`: Algorithm to use. 
-    `NaiveCoordinateDescent` iteratively computes the dot product of the 
-    predictors with the  residuals, as opposed to the         
-    `CovarianceCoordinateDescent` algorithm, which uses a precomputed Gram matrix.                
-    `NaiveCoordinateDescent` is typically faster when there are many  
-    predictors that will not enter the model or when fitting        
-    generalized linear models.                                      
-    By default uses `NaiveCoordinateDescent` if more than 5x as many predictors 
+- `algorithm`: Algorithm to use.
+    `NaiveCoordinateDescent` iteratively computes the dot product of the
+    predictors with the  residuals, as opposed to the
+    `CovarianceCoordinateDescent` algorithm, which uses a precomputed Gram matrix.
+    `NaiveCoordinateDescent` is typically faster when there are many
+    predictors that will not enter the model or when fitting
+    generalized linear models.
+    By default uses `NaiveCoordinateDescent` if more than 5x as many predictors
     as observations or model is a GLM. `CovarianceCoordinateDescent` otherwise.
 - `randomize=true`: Whether to randomize the order in which coefficients are
     updated by coordinate descent. This can drastically speed
     convergence if coefficients are highly correlated.
-- `maxncoef=min(size(X, 2), 2*size(X, 1))`: maximum number of coefficients 
+- `maxncoef=min(size(X, 2), 2*size(X, 1))`: maximum number of coefficients
     allowed in the model. If exceeded, an error will be thrown.
-- `dofit=true`: Whether to fit the model upon construction. If `false`, the 
+- `dofit=true`: Whether to fit the model upon construction. If `false`, the
     model can be fit later by calling `fit!(model)`.
 - `cd_tol=1e-7`: The tolerance for coordinate descent iterations iterations in
     the inner loop.
@@ -417,7 +421,7 @@ fit(LassoPath, X, y, Binomial(), Logit();
     between successive iterations drops below the specified
     tolerance. This is the criterion used by GLM.jl.
 - `minStepFac=0.001`: The minimum step fraction for backtracking line search.
-- `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\\omega_j`` 
+- `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\\omega_j``
     for each coefficient ``j``, i.e. instead of ``\\lambda`` penalties become
     ``\\lambda\\omega_j``.
     Note the penalty factors are internally rescaled to sum to

--- a/src/segselect.jl
+++ b/src/segselect.jl
@@ -54,7 +54,7 @@ CVfun(oosdevs, ::MinCV1se) = CV1se(oosdevs)
 
 """
     coef(path::RegularizationPath; kwargs...)
-    
+
 Coefficient vector for a selected segment of a regularization path.
 
 # Examples
@@ -67,7 +67,7 @@ StatsBase.coef(path::RegularizationPath; select=AllSeg(), kwargs...) = coef(path
 
 """
     coef(path::RegularizationPath, select::SegSelect)
-    
+
 Coefficient vector for a selected segment of a regularization path.
 
 # Examples
@@ -130,8 +130,8 @@ pathtype(::Type{GammaLassoModel}) = GammaLassoPath
 
 """
     selectmodel(path::RegularizationPath, select::SegSelect)
-    
-Returns a LinearModel or GeneralizedLinearModel representing the selected 
+
+Returns a LinearModel or GeneralizedLinearModel representing the selected
 segment of a regularization path.
 
 # Examples
@@ -163,47 +163,47 @@ end
 
 """
     fit(RegularizedModel, X, y, dist, link; <kwargs>)
-    
-Returns a LinearModel or GeneralizedLinearModel representing the selected 
+
+Returns a LinearModel or GeneralizedLinearModel representing the selected
 segment of a regularization path.
 
 # Examples
 ```julia
-fit(LassoModel, X, y; select=MinBIC()) # BIC minimizing LinearModel 
-fit(LassoModel, X, y, Binomial(), Logit(); 
+fit(LassoModel, X, y; select=MinBIC()) # BIC minimizing LinearModel
+fit(LassoModel, X, y, Binomial(), Logit();
     select=MinCVmse(path, 5)) # 5-fold CV mse minimizing model
 ```
 # Arguments
 - `select::SegSelect=MinAICc()`: segment selector.
-- `wts=ones(length(y))`: Weights for each observation                                    
-- `offset=zeros(length(y))`: Offset of each observation                                    
-- `λ`: can be used to specify a specific set of λ values at which models are fit. 
+- `wts=ones(length(y))`: Weights for each observation
+- `offset=zeros(length(y))`: Offset of each observation
+- `λ`: can be used to specify a specific set of λ values at which models are fit.
     If λ is unspecified, Lasso.jl selects nλ logarithmically spaced λ values from
     `λmax`, the smallest λ value yielding a null model, to
     `λminratio * λmax`.
 - `nλ=100` number of λ values to use
 - `λminratio=1e-4` if more observations than predictors otherwise 0.001.
-- `stopearly=true`: When `true`, if the proportion of deviance explained 
+- `stopearly=true`: When `true`, if the proportion of deviance explained
     exceeds 0.999 or the difference between the deviance explained by successive λ
-    values falls below `1e-5`, the path stops early.                                    
-- `standardize=true`: Whether to standardize predictors to unit standard deviation 
-    before fitting.                              
+    values falls below `1e-5`, the path stops early.
+- `standardize=true`: Whether to standardize predictors to unit standard deviation
+    before fitting.
 - `intercept=true`: Whether to fit an (unpenalized) model intercept.
-- `algorithm`: Algorithm to use. 
-    `NaiveCoordinateDescent` iteratively computes the dot product of the 
-    predictors with the  residuals, as opposed to the         
-    `CovarianceCoordinateDescent` algorithm, which uses a precomputed Gram matrix.                
-    `NaiveCoordinateDescent` is typically faster when there are many  
-    predictors that will not enter the model or when fitting        
-    generalized linear models.                                      
-    By default uses `NaiveCoordinateDescent` if more than 5x as many predictors 
+- `algorithm`: Algorithm to use.
+    `NaiveCoordinateDescent` iteratively computes the dot product of the
+    predictors with the  residuals, as opposed to the
+    `CovarianceCoordinateDescent` algorithm, which uses a precomputed Gram matrix.
+    `NaiveCoordinateDescent` is typically faster when there are many
+    predictors that will not enter the model or when fitting
+    generalized linear models.
+    By default uses `NaiveCoordinateDescent` if more than 5x as many predictors
     as observations or model is a GLM. `CovarianceCoordinateDescent` otherwise.
 - `randomize=true`: Whether to randomize the order in which coefficients are
     updated by coordinate descent. This can drastically speed
     convergence if coefficients are highly correlated.
-- `maxncoef=min(size(X, 2), 2*size(X, 1))`: maximum number of coefficients 
+- `maxncoef=min(size(X, 2), 2*size(X, 1))`: maximum number of coefficients
     allowed in the model. If exceeded, an error will be thrown.
-- `dofit=true`: Whether to fit the model upon construction. If `false`, the 
+- `dofit=true`: Whether to fit the model upon construction. If `false`, the
     model can be fit later by calling `fit!(model)`.
 - `cd_tol=1e-7`: The tolerance for coordinate descent iterations iterations in
     the inner loop.
@@ -220,7 +220,7 @@ fit(LassoModel, X, y, Binomial(), Logit();
     between successive iterations drops below the specified
     tolerance. This is the criterion used by GLM.jl.
 - `minStepFac=0.001`: The minimum step fraction for backtracking line search.
-- `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\\omega_j`` 
+- `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\\omega_j``
     for each coefficient ``j``, i.e. instead of ``\\lambda`` penalties become
     ``\\lambda\\omega_j``.
     Note the penalty factors are internally rescaled to sum to
@@ -242,3 +242,6 @@ end
 
 newglm(m::LinearModel, pp) = LinearModel(m.rr, pp)
 newglm(m::GeneralizedLinearModel, pp) = GeneralizedLinearModel(m.rr, pp, true)
+
+# don't add an intercept when using a @formula because we use the intercept keyword arg to add an intercept
+StatsModels.drop_intercept(::Type{R}) where R<:RegularizedModel = true

--- a/src/segselect.jl
+++ b/src/segselect.jl
@@ -273,7 +273,7 @@ function StatsBase.fit(::Type{R}, X::AbstractMatrix{T}, y::V,
 
     # fit a regularization path
     M = pathtype(R)
-    path = fit(M, X, y, d, l; kwargs...)
+    path = fit(M, X, y, d, l; intercept=intercept, kwargs...)
 
     R(selectmodel(path, select), intercept)
 end
@@ -292,7 +292,8 @@ for modeltype in (:LassoModel, :GammaLassoModel)
                                      StatsBase.loglikelihood, StatsBase.nullloglikelihood,
                                      StatsBase.dof, StatsBase.dof_residual, StatsBase.nobs,
                                      StatsBase.stderror, StatsBase.vcov,
-                                     StatsBase.residuals, StatsBase.response
+                                     StatsBase.residuals, StatsBase.response,
+                                     StatsBase.coeftable
                                      ]
     end
 end

--- a/src/segselect.jl
+++ b/src/segselect.jl
@@ -54,7 +54,7 @@ CVfun(oosdevs, ::MinCV1se) = CV1se(oosdevs)
 
 """
     coef(path::RegularizationPath; kwargs...)
-    
+
 Coefficient vector for a selected segment of a regularization path.
 
 # Examples
@@ -67,7 +67,7 @@ StatsBase.coef(path::RegularizationPath; select=AllSeg(), kwargs...) = coef(path
 
 """
     coef(path::RegularizationPath, select::SegSelect)
-    
+
 Coefficient vector for a selected segment of a regularization path.
 
 # Examples
@@ -118,11 +118,37 @@ segselect(path::RegularizationPath,
 "A RegularizedModel represents selected segment from a RegularizationPath"
 abstract type RegularizedModel <: RegressionModel end
 
-"A LassoModel represents selected segment from a LassoPath"
-abstract type LassoModel <: RegularizedModel end
+"LassoModel represents a selected segment from a LassoPath"
+struct LassoModel{M<:LinPredModel} <: RegularizedModel
+    lpm::M          # underlying GLM
+    intercept::Bool # whether path added an intercept
+end
 
-"A GammaLassoModel represents selected segment from a GammaLassoPath"
-abstract type GammaLassoModel <: RegularizedModel end
+"GammaLassoModel represents a selected segment from a GammaLassoPath"
+struct GammaLassoModel{M<:LinPredModel} <: RegularizedModel
+    lpm::M          # underlying GLM
+    intercept::Bool # whether path added an intercept
+end
+
+"""
+predict(m::RegularizedModel, newX::AbstractMatrix; kwargs...)
+
+Predicted values using a selected segment of a regularization path.
+
+# Examples
+```julia
+m = fit(LassoModel, X, y; select=MinBIC())
+predict(m, newX)     # predict using BIC minimizing segment
+"""
+function StatsBase.predict(m::RegularizedModel, newX::AbstractMatrix{T}; kwargs...) where {T<:AbstractFloat}
+    # add an interecept to newX if the model has one
+    if m.intercept
+        newX = [ones(T,size(newX,1),1) newX]
+    end
+
+    predict(m.lpm, newX; kwargs...)
+end
+StatsBase.predict(m::RegularizedModel) = predict(m.lpm)
 
 "Returns the RegularizedPath type R used in fit(R,...)"
 pathtype(::Type{LassoModel}) = LassoPath
@@ -130,8 +156,8 @@ pathtype(::Type{GammaLassoModel}) = GammaLassoPath
 
 """
     selectmodel(path::RegularizationPath, select::SegSelect)
-    
-Returns a LinearModel or GeneralizedLinearModel representing the selected 
+
+Returns a LinearModel or GeneralizedLinearModel representing the selected
 segment of a regularization path.
 
 # Examples
@@ -172,47 +198,47 @@ end
 
 """
     fit(RegularizedModel, X, y, dist, link; <kwargs>)
-    
-Returns a LinearModel or GeneralizedLinearModel representing the selected 
+
+Returns a LinearModel or GeneralizedLinearModel representing the selected
 segment of a regularization path.
 
 # Examples
 ```julia
-fit(LassoModel, X, y; select=MinBIC()) # BIC minimizing LinearModel 
-fit(LassoModel, X, y, Binomial(), Logit(); 
+fit(LassoModel, X, y; select=MinBIC()) # BIC minimizing LinearModel
+fit(LassoModel, X, y, Binomial(), Logit();
     select=MinCVmse(path, 5)) # 5-fold CV mse minimizing model
 ```
 # Arguments
 - `select::SegSelect=MinAICc()`: segment selector.
-- `wts=ones(length(y))`: Weights for each observation                                    
-- `offset=zeros(length(y))`: Offset of each observation                                    
-- `λ`: can be used to specify a specific set of λ values at which models are fit. 
+- `wts=ones(length(y))`: Weights for each observation
+- `offset=zeros(length(y))`: Offset of each observation
+- `λ`: can be used to specify a specific set of λ values at which models are fit.
     If λ is unspecified, Lasso.jl selects nλ logarithmically spaced λ values from
     `λmax`, the smallest λ value yielding a null model, to
     `λminratio * λmax`.
 - `nλ=100` number of λ values to use
 - `λminratio=1e-4` if more observations than predictors otherwise 0.001.
-- `stopearly=true`: When `true`, if the proportion of deviance explained 
+- `stopearly=true`: When `true`, if the proportion of deviance explained
     exceeds 0.999 or the difference between the deviance explained by successive λ
-    values falls below `1e-5`, the path stops early.                                    
-- `standardize=true`: Whether to standardize predictors to unit standard deviation 
-    before fitting.                              
+    values falls below `1e-5`, the path stops early.
+- `standardize=true`: Whether to standardize predictors to unit standard deviation
+    before fitting.
 - `intercept=true`: Whether to fit an (unpenalized) model intercept.
-- `algorithm`: Algorithm to use. 
-    `NaiveCoordinateDescent` iteratively computes the dot product of the 
-    predictors with the  residuals, as opposed to the         
-    `CovarianceCoordinateDescent` algorithm, which uses a precomputed Gram matrix.                
-    `NaiveCoordinateDescent` is typically faster when there are many  
-    predictors that will not enter the model or when fitting        
-    generalized linear models.                                      
-    By default uses `NaiveCoordinateDescent` if more than 5x as many predictors 
+- `algorithm`: Algorithm to use.
+    `NaiveCoordinateDescent` iteratively computes the dot product of the
+    predictors with the  residuals, as opposed to the
+    `CovarianceCoordinateDescent` algorithm, which uses a precomputed Gram matrix.
+    `NaiveCoordinateDescent` is typically faster when there are many
+    predictors that will not enter the model or when fitting
+    generalized linear models.
+    By default uses `NaiveCoordinateDescent` if more than 5x as many predictors
     as observations or model is a GLM. `CovarianceCoordinateDescent` otherwise.
 - `randomize=true`: Whether to randomize the order in which coefficients are
     updated by coordinate descent. This can drastically speed
     convergence if coefficients are highly correlated.
-- `maxncoef=min(size(X, 2), 2*size(X, 1))`: maximum number of coefficients 
+- `maxncoef=min(size(X, 2), 2*size(X, 1))`: maximum number of coefficients
     allowed in the model. If exceeded, an error will be thrown.
-- `dofit=true`: Whether to fit the model upon construction. If `false`, the 
+- `dofit=true`: Whether to fit the model upon construction. If `false`, the
     model can be fit later by calling `fit!(model)`.
 - `cd_tol=1e-7`: The tolerance for coordinate descent iterations iterations in
     the inner loop.
@@ -229,7 +255,7 @@ fit(LassoModel, X, y, Binomial(), Logit();
     between successive iterations drops below the specified
     tolerance. This is the criterion used by GLM.jl.
 - `minStepFac=0.001`: The minimum step fraction for backtracking line search.
-- `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\\omega_j`` 
+- `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\\omega_j``
     for each coefficient ``j``, i.e. instead of ``\\lambda`` penalties become
     ``\\lambda\\omega_j``.
     Note the penalty factors are internally rescaled to sum to
@@ -241,13 +267,15 @@ See also [`fit(::RegularizationPath...)`](@ref) for a full list of arguments
 """
 function StatsBase.fit(::Type{R}, X::AbstractMatrix{T}, y::V,
     d::UnivariateDistribution=Normal(), l::Link=canonicallink(d);
-    select::SegSelect=MinAICc(), kwargs...) where {R<:RegularizedModel,T<:AbstractFloat,V<:FPVector}
+    select::SegSelect=MinAICc(),
+    intercept=true,
+    kwargs...) where {R<:RegularizedModel,T<:AbstractFloat,V<:FPVector}
 
     # fit a regularization path
     M = pathtype(R)
     path = fit(M, X, y, d, l; kwargs...)
 
-    selectmodel(path, select)
+    R(selectmodel(path, select), intercept)
 end
 
 newglm(m::LinearModel, pp) = LinearModel(m.rr, pp)
@@ -257,6 +285,17 @@ newglm(m::GeneralizedLinearModel, pp) = GeneralizedLinearModel(m.rr, pp, true)
 StatsModels.drop_intercept(::Type{R}) where R<:RegularizedModel = true
 
 StatsModels.@delegate StatsModels.DataFrameRegressionModel.model [segselect, MinCVmse, MinCV1se]
+for modeltype in (:LassoModel, :GammaLassoModel)
+    @eval begin
+        StatsModels.@delegate $modeltype.lpm [StatsBase.coef, StatsBase.confint,
+                                     StatsBase.deviance, StatsBase.nulldeviance,
+                                     StatsBase.loglikelihood, StatsBase.nullloglikelihood,
+                                     StatsBase.dof, StatsBase.dof_residual, StatsBase.nobs,
+                                     StatsBase.stderror, StatsBase.vcov,
+                                     StatsBase.residuals, StatsBase.response
+                                     ]
+    end
+end
 
 # same ediom as in https://github.com/JuliaStats/GLM.jl/blob/0926a95dfc2b09179151683053de7c69e22bbe2b/src/glmfit.jl#L375
 # makes converts X and y to floats

--- a/test/lasso.jl
+++ b/test/lasso.jl
@@ -22,7 +22,7 @@ function genrand(T::DataType, d::Distribution, l::GLM.Link, nsamples::Int, nfeat
     X, coef = makeX(0.0, nsamples, nfeatures, sparse)
     y = X*coef
     for i = 1:length(y)
-        y[i] = randdist(d, linkinv(l, y[i]))
+        y[i] = randdist(d, GLM.linkinv(l, y[i]))
     end
     (X, y)
 end

--- a/test/segselect.jl
+++ b/test/segselect.jl
@@ -24,13 +24,13 @@ datapath = joinpath(dirname(@__FILE__), "data")
                 pathcoefs = coef(path, select)
 
                 Random.seed!(421)
-                pathpredict = predict(path, data; select=select, offset=offset)
+                pathpredict = Lasso.predict(path, data; select=select, offset=offset)
 
                 @test pathcoefs == coef(m)
                 if isa(dist, Normal)
-                    @test pathpredict == predict(m, data) + offset
+                    @test pathpredict == GLM.predict(m, data) + offset
                 else
-                    @test pathpredict == predict(m, data; offset=offset)
+                    @test pathpredict == GLM.predict(m, data; offset=offset)
                 end
             end
         end


### PR DESCRIPTION
Previously the StatsModels.DataFramesRegressionModel was incompatible with Lasso.jl's using a keyword argument for the intercept, so `fit(LassoPath, formula(Y~X), df)` did not work properly.

`fit(LassoModel, @formula(Y~X), df; select=MinAIC())` did not work at all.

This PR fixes that issue and adds tests for both.