### PR TITLE
Cap StatsModels at v0.5 and require GLM v1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
-GLM = "1.0, 1.1, 1.2"
+GLM = "1.2"
 StatsModels = "0.4, 0.5"
 julia = "0.7, 1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,11 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
+GLM = "1.0, 1.1, 1.2"
+StatsModels = "0.4, 0.5"
 julia = "0.7, 1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lasso"
 uuid = "b4fcebef-c861-5a0f-a7e2-ba9dc32b180a"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-julia = "≥ 0.7.0"
+julia = "0.7, 1"
 
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -315,7 +315,7 @@ function build_model(X::AbstractMatrix{T}, y::FPVector, d::UnivariateDistributio
     # Fit to find null deviance
     # Maybe we should reuse this GlmResp object?
     nullmodel = fit(GeneralizedLinearModel, nullX(X, intercept, ω), y, d, l;
-                    wts=wts, offset=offset, convTol=irls_tol, dofit=dofit)
+                    wts=wts, offset=offset, rtol=irls_tol, dofit=dofit)
     nulldev = deviance(nullmodel)
     nullb0 = intercept ? coef(nullmodel)[1] : zero(T)
 


### PR DESCRIPTION
* StatsModels changed significantly at 0.6 but GLM is not yet supporting it, so for now cap version
* GLM 1.2 also changed `convTol` to `rtol` in `fit!`