### PR TITLE
Allow passing a function to generate λ

### DIFF
--- a/test/lasso.jl
+++ b/test/lasso.jl
@@ -133,6 +133,15 @@ end
                                             end
                                             #     end
                                             # end
+                                            # With a function to generate λ
+                                            λfunc(λmax) = range(λmax, stop=g.lambda[end], length=3)
+                                            lf = fit(LassoPath, spfit ? sparse(X) : X, y, dist, link,
+                                                     λ=λfunc, algorithm=algorithm, intercept=intercept,
+                                                     cd_tol=cd_tol, irls_tol=irls_tol, criterion=criterion, randomize=randomize,
+                                                     α=alpha, offset=offset, penalty_factor=penalty_factor)
+                                            @test length(lf.λ) == 3
+                                            @test_skip all(iszero, lf.coefs[:,1])
+                                            @test lf.coefs[:,end] ≈ l.coefs[:,end]
                                         end
                                     end
                                 end


### PR DESCRIPTION
In some circumstances it's nice to test lasso all the way down to `λ=0` (if, for example, one has a least-squares prediction), but the approach taken here doesn't make that straightforward. I felt that the most flexible approach would be to allow users to provide a function that generates the list of `λ` from `λmax`. The advantage of using a function is that calculating `λmax` is nontrivial, so to avoid repeating work it's best to calculate `λ` after `λmax` is known.

One of the tests here is marked `@test_skip` because the solution with `λmax` turns out not to always be null. That seems to be a violation of the documentation for `fit`, but I decided fixing that was beyond the scope of this PR.