### PR TITLE
Clarify the documentation

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,3 +3,6 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Lasso = "b4fcebef-c861-5a0f-a7e2-ba9dc32b180a"
 MLBase = "f0e99cf1-93fa-52ec-9ecc-5026115318e0"
+
+[compat]
+Documenter = "0.24"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,8 +27,9 @@ Journal of Computational and Graphical Statistics, 26:3, 525-536.
 
 ## Quick start
 
-### Lasso (L1-penalized) Ordinary Least Squares Regression:
-```jldoctest
+### Lasso (L1-penalized) Ordinary Least Squares Regression
+
+```jldoctest demo1
 julia> using DataFrames, Lasso
 
 julia> data = DataFrame(X=[1,2,3], Y=[2,4,7])
@@ -39,9 +40,21 @@ julia> data = DataFrame(X=[1,2,3], Y=[2,4,7])
 │ 1   │ 1     │ 2     │
 │ 2   │ 2     │ 4     │
 │ 3   │ 3     │ 7     │
+```
 
+Let's fit this to a model
+
+``
+Y = x_1 + x_2 X
+``
+
+for some scalar coefficients ``x_1`` and ``x_2``. The least-squares answer is ``x_2 = 2.5``
+and ``x_1 = -2/3``,
+but with lasso regularization you penalize the magnitude of `x2`. Consequently,
+
+```jldoctest demo1
 julia> m = fit(LassoModel, @formula(Y ~ X), data)
-LassoModel using MinAICc(2) segment of the regulatization path.
+LassoModel using MinAICc(2) segment of the regularization path.
 
 Coefficients:
 ────────────
@@ -63,11 +76,18 @@ julia> predict(m, data[2:end,:])
  4.555426443044614
 ```
 
-To get an entire Lasso regularization path with default parameters:
+In the variant above, it automatically picks the size of penalty to apply to ``x_2``.
+
+To get an entire Lasso regularization path (thus examining the consequences of a range
+of penalties) with default parameters:
 
 ```julia
 fit(LassoPath, X, y, dist, link)
 ```
+
+where `X` is now the [design matrix](https://en.wikipedia.org/wiki/Design_matrix),
+omitting the column of 1s allowing for the intercept, and `y` is the vector of
+values to be fit.
 
 `dist` is any distribution supported by GLM.jl and `link` defaults to
 the canonical link for that distribution.

--- a/docs/src/lasso.md
+++ b/docs/src/lasso.md
@@ -1,11 +1,12 @@
 # Lasso paths
 
 ```@docs
-fit
+fit(::Type{LassoPath}, ::Matrix{Float64}, ::Vector{Float64})
 ```
 
 ## Returned objects
-``fit`` returns a `RegularizationPath` object describing the fit coefficients
+
+`fit` returns a `RegularizationPath` object describing the fit coefficients
 and values of λ along the path. The following fields are
 intended for external use:
 
@@ -23,8 +24,15 @@ Tibshirani, R. (2010). Regularization paths for generalized linear
 models via coordinate descent. Journal of Statistical Software,
 33(1), 1.
 
+## Gamma paths
+
+```@docs
+fit(::Type{GammaLassoPath}, ::Matrix{Float64}, ::Vector{Float64})
+```
+
 ## Using the model
-Lasso adhears to most of the `StatsBase` interface, so `coef` and `predict`
+
+Lasso adheres to most of the `StatsBase` interface, so `coef` and `predict`
 should work as expected, except that a particular segment of the path
 would need to be selected.
 
@@ -37,6 +45,7 @@ size
 ```
 
 ## Segment selectors
+
 ```@docs
 SegSelect
 segselect
@@ -50,6 +59,7 @@ AllSeg
 ```
 
 ## Lasso model fitting
+
 Often one wishes to both fit the path and select a particular segment.
 This can be done with `fit(RegularizedModel,...)`, which returns a fitted
 `RegularizedModel` wrapping a `GLM` representation of the selected model.
@@ -73,7 +83,7 @@ julia> data = DataFrame(X=[1,2,3], Y=[2,4,7])
 │ 3   │ 3     │ 7     │
 
 julia> m = fit(LassoModel, @formula(Y ~ X), data; select=MinCVmse(Kfold(3,2)))
-LassoModel using MinCVmse(Kfold([3, 1, 2], 2, 1.5)) segment of the regulatization path.
+LassoModel using MinCVmse(Kfold([3, 1, 2], 2, 1.5)) segment of the regularization path.
 
 Coefficients:
 ────────────
@@ -95,4 +105,5 @@ RegularizedModel
 LassoModel
 GammaLassoModel
 selectmodel
+fit(::Type{<:RegularizedModel}, ::Matrix{Float64}, ::Vector{Float64})
 ```

--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -360,13 +360,15 @@ end
 fits a linear or generalized linear Lasso path given the design
 matrix `X` and response `y`:
 
-``\underset{\beta}{\operatorname{argmin}} -\frac{1}{N} \mathcal{L}(y|X,\beta) + \lambda\left[(1-\alpha)\frac{1}{2}\|\beta\|_2^2 + \alpha\|\beta\|_1\right]``
+``\underset{\beta,b_0}{\operatorname{argmin}} -\frac{1}{N} \mathcal{L}(y|X,\beta,b_0) + \lambda\left[(1-\alpha)\frac{1}{2}\|\beta\|_2^2 + \alpha\|\beta\|_1\right]``
 
+where ``0 \le \alpha \le 1`` sets the balance between ridge (``\alpha = 0``)
+and lasso (``\alpha = 1``) regression, and ``N`` is the number of rows of ``X``.
 The optional argument `d` specifies the conditional distribution of
 response, while `l` specifies the link function. Lasso.jl inherits
 supported distributions and link functions from GLM.jl. The default
 is to fit an linear Lasso path, i.e., `d=Normal(), l=IdentityLink()`,
-or ``\mathcal{L}(y|X,\beta) = -\frac{1}{2}\|y - X\beta\|_2^2 + C``
+or ``\mathcal{L}(y|X,\beta) = -\frac{1}{2}\|y - X\beta - b_0\|_2^2 + C``
 
 # Examples
 ```julia
@@ -389,7 +391,7 @@ fit(LassoPath, X, y, Binomial(), Logit();
     values falls below `1e-5`, the path stops early.
 - `standardize=true`: Whether to standardize predictors to unit standard deviation
     before fitting.
-- `intercept=true`: Whether to fit an (unpenalized) model intercept.
+- `intercept=true`: Whether to fit an (unpenalized) model intercept ``b_0``. If false, ``b_0=0``.
 - `algorithm`: Algorithm to use.
     `NaiveCoordinateDescent` iteratively computes the dot product of the
     predictors with the  residuals, as opposed to the
@@ -410,16 +412,15 @@ fit(LassoPath, X, y, Binomial(), Logit();
     the inner loop.
 - `irls_tol=1e-7`: The tolerance for outer iteratively reweighted least squares
     iterations. This is ignored unless the model is a generalized linear model.
-- `criterion=:coef` Convergence criterion. Controls how ``cd_tol`` and ``irls_tol``
+- `criterion=:coef` Convergence criterion. Controls how `cd_tol` and `irls_tol`
     are to be interpreted. Possible values are:
-    - ``:coef``: The model is considered to have converged if the
-    the maximum absolute squared difference in coefficients
-    between successive iterations drops below the specified
-    tolerance. This is the criterion used by glmnet.
-    - ``:obj``: The model is considered to have converged if the
-    the relative change in the Lasso/Elastic Net objective
-    between successive iterations drops below the specified
-    tolerance. This is the criterion used by GLM.jl.
+    - `:coef`: The model is considered to have converged if the
+      the maximum absolute squared difference in coefficients
+      between successive iterations drops below the specified
+      tolerance. This is the criterion used by glmnet.
+    - `:obj`: The model is considered to have converged if the the relative change
+      in the Lasso/Elastic Net objective between successive iterations drops below
+      the specified tolerance. This is the criterion used by GLM.jl.
 - `minStepFac=0.001`: The minimum step fraction for backtracking line search.
 - `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\omega_j``
     for each coefficient ``j``, i.e. instead of ``\lambda`` penalties become

--- a/src/segselect.jl
+++ b/src/segselect.jl
@@ -256,16 +256,16 @@ fit(LassoModel, X, y, Binomial(), Logit();
     the inner loop.
 - `irls_tol=1e-7`: The tolerance for outer iteratively reweighted least squares
     iterations. This is ignored unless the model is a generalized linear model.
-- `criterion=:coef` Convergence criterion. Controls how ``cd_tol`` and ``irls_tol``
+- `criterion=:coef` Convergence criterion. Controls how `cd_tol` and `irls_tol`
     are to be interpreted. Possible values are:
-    - ``:coef``: The model is considered to have converged if the
-    the maximum absolute squared difference in coefficients
-    between successive iterations drops below the specified
-    tolerance. This is the criterion used by glmnet.
-    - ``:obj``: The model is considered to have converged if the
-    the relative change in the Lasso/Elastic Net objective
-    between successive iterations drops below the specified
-    tolerance. This is the criterion used by GLM.jl.
+    - `:coef`: The model is considered to have converged if the
+      the maximum absolute squared difference in coefficients
+      between successive iterations drops below the specified
+      tolerance. This is the criterion used by glmnet.
+    - `:obj`: The model is considered to have converged if the
+      the relative change in the Lasso/Elastic Net objective
+      between successive iterations drops below the specified
+      tolerance. This is the criterion used by GLM.jl.
 - `minStepFac=0.001`: The minimum step fraction for backtracking line search.
 - `penalty_factor=ones(size(X, 2))`: Separate penalty factor ``\\omega_j``
     for each coefficient ``j``, i.e. instead of ``\\lambda`` penalties become
@@ -275,7 +275,7 @@ fit(LassoModel, X, y, Binomial(), Logit();
 - `standardizeω=true`: Whether to scale penalty factors to sum to the number of
     variables (glmnet.R convention).
 
-See also [`fit(::RegularizationPath...)`](@ref) for a full list of arguments
+See also [`fit(::Type{LassoPath}, ::Matrix{Float64}, ::Vector{Float64})`](@ref) for a more complete list of arguments
 """
 function StatsBase.fit(::Type{R}, X::AbstractMatrix{T}, y::V,
     d::UnivariateDistribution=Normal(), l::Link=canonicallink(d);
@@ -326,7 +326,7 @@ end
     
 function Base.show(io::IO, obj::RegularizedModel)
     # prefix = isa(obj.m, GeneralizedLinearModel) ? string(typeof(distfun(path)).name.name, " ") : ""
-    println(io, "$(typeof(obj).name.name) using $(obj.select) segment of the regulatization path.")
+    println(io, "$(typeof(obj).name.name) using $(obj.select) segment of the regularization path.")
 
     println(io, "\nCoefficients:\n", coeftable(obj))
 end


### PR DESCRIPTION
- There are many symbols not explained.
- It needs to be specified whether an intercept is implicitly allowed, and whether that should be included in the design matrix.
- It also seems that the `fit` API was described in a block, but sections that follow correspond to particular `fit` methods, so I decided to split different `fit` methods across differerent sections of the documentation.
- There were several typos and formatting errors.

CC @ChantalJuntao.