### PR TITLE
Correctly handling the case λmax = 0.

### DIFF
--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -209,6 +209,10 @@ const MAX_DEV_FRAC = 0.999
 # Compute automatic λ values based on λmax and λminratio
 function computeλ(λmax, λminratio, α, nλ)
     λmax /= α
+    if λmax == 0
+        @info "The penalized coefficients equal zero for all values of the regularisation parameter λ."
+        return [λmax]
+    end
     logλmax = log(λmax)
     exp.(range(logλmax, stop=logλmax + log(λminratio), length=nλ))
 end


### PR DESCRIPTION
Two changes:
1) Change to computeλ to ensure λmax = 0 leads to an output of [0] and 
not [NaN, ..., NaN].
2) Change to fit! to ensure the case where autoλ = true and λmax = 0 is 
handled correctly (rather than throwing an error).