### PR TITLE
bump DSP compat to 0.7; fix csv-to-matrix function to DataFrames 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 
 [compat]
-DSP = "0.6"
+DSP = "0.6, 0.7"
 Distributions = "0.24"
 GLM = "1.3"
 MLBase = "0.8"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -10,3 +10,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+DataFrames = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test, Lasso, StableRNGs
 const testrng = StableRNG(13)
 
 using CSV, DataFrames
-readcsvmat(path;header=false, kwargs...) = convert(Matrix{Float64}, DataFrame(CSV.File(path;header=header, kwargs...)))
+readcsvmat(path;header=false, kwargs...) = Matrix{Float64}(DataFrame(CSV.File(path;header=header, kwargs...)))
 
 @testset "Lasso" begin
 


### PR DESCRIPTION
DSP 0.7 was released recently, with changes that don't affect the use of `filt!` here AFAIK.

This also fixes the function to convert a dataframe into a matrix since it was erroring with DataFrames 1.