### PR TITLE
Fix dropcollinear issue with an empty nullmodel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 [compat]
 DSP = "0.7"
 Distributions = "0.25"
-GLM = "1.5"
+GLM = "1.8"
 MLBase = "0.9"
 Reexport = "1"
 StatsBase = "0.33"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lasso"
 uuid = "b4fcebef-c861-5a0f-a7e2-ba9dc32b180a"
-version = "0.6.3"
+version = "0.7.0"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"

--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -330,8 +330,13 @@ function build_model(X::AbstractMatrix{T}, y::FPVector, d::UnivariateDistributio
                      wts::Union{FPVector,Nothing}, offset::Vector, α::Real, nλ::Int,
                      ω::Union{Vector, Nothing}, intercept::Bool, irls_tol::Real, dofit::Bool) where T
     # Fit to find null deviance
+    X0 = nullX(X, intercept, ω)
+
+    # Drop collinear X columns only if it has any (cholpred gives very large rank otherwise)
+    dropcollinear = size(X0,2) > 0
+
     # Maybe we should reuse this GlmResp object?
-    nullmodel = fit(GeneralizedLinearModel, nullX(X, intercept, ω), y, d, l;
+    nullmodel = fit(GeneralizedLinearModel, X0, y, d, l; dropcollinear=dropcollinear,
                     wts=wts, offset=offset, rtol=irls_tol, dofit=dofit)
     nulldev = deviance(nullmodel)
     nullb0 = intercept ? coef(nullmodel)[1] : zero(T)


### PR DESCRIPTION
Starting with GLM v1.8.1 fit() passes dropcollinear=true by default.
Lasso uses GLM.fit() to build a nullmodel with unregularized X variables.
When this matrix had zero columns, dropcollinear would check for its rank and get a very large number causing issues.
We now do not dropcollinear when size(X,2)==0.

Because the dropping of collinear unregularized columns is a change in behavior, I am bumping up the version accordingly.