### PR TITLE
Support for StatsBase v0.34 and StatsModels v0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Lasso"
 uuid = "b4fcebef-c861-5a0f-a7e2-ba9dc32b180a"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
@@ -20,6 +20,6 @@ Distributions = "0.25"
 GLM = "1.8"
 MLBase = "0.9"
 Reexport = "1"
-StatsBase = "0.33"
-StatsModels = "0.6"
+StatsBase = "0.33, 0.34"
+StatsModels = "0.6, 0.7"
 julia = "1"


### PR DESCRIPTION
Now that MLBase [supports](https://github.com/JuliaStats/MLBase.jl/pull/59) the newer version of StatsBase it can be supported by Lasso too. 

Also bumps compat for StatsModels to v0.7 which didn't really affect Lasso.