### PR TITLE
Pass rng to MinCVmse and MinCV1se

### DIFF
--- a/src/segselect.jl
+++ b/src/segselect.jl
@@ -34,7 +34,7 @@ struct MinCVmse <: CVSegSelect
     gen::CrossValGenerator
 
     MinCVmse(gen::CrossValGenerator) = new(gen)
-    MinCVmse(path::RegularizationPath, k::Int=10) = new(Kfold(length(path.m.rr.y), k))
+    MinCVmse(path::RegularizationPath, k::Int=10; rng::AbstractRNG = Random.default_rng()) = new(Kfold(rng, length(path.m.rr.y), k))
 end
 
 CVfun(oosdevs, ::MinCVmse) = CVmin(oosdevs)
@@ -47,7 +47,7 @@ struct MinCV1se <: CVSegSelect
     gen::CrossValGenerator
 
     MinCV1se(gen::CrossValGenerator) = new(gen)
-    MinCV1se(path::RegularizationPath, k::Int=10) = new(Kfold(length(path.m.rr.y), k))
+    MinCV1se(path::RegularizationPath, k::Int=10; rng::AbstractRNG = Random.default_rng()) = new(Kfold(rng, length(path.m.rr.y), k))
 end
 
 CVfun(oosdevs, ::MinCV1se) = CV1se(oosdevs)

--- a/test/segselect.jl
+++ b/test/segselect.jl
@@ -29,7 +29,7 @@ datapath = joinpath(dirname(@__FILE__), "data")
         @testset "$f" for (f,intercept) in ((@formula(y~x1+x2+x3), true), (@formula(y~0+x1+x2+x3), false))
             path = fit(R, f, data, dist, link; intercept=intercept, offset=offset)
 
-            @testset "$(typeof(select))" for select in [MinAIC(), MinAICc(), MinBIC(), MinCVmse(path), MinCV1se(path)]
+            @testset "$(typeof(select))" for select in [MinAIC(), MinAICc(), MinBIC(), MinCVmse(path), MinCV1se(path), MinCVmse(path; rng = StableRNG(421)), MinCV1se(path; rng = StableRNG(421))]
                 Random.seed!(421)
                 m = fit(L, f, data, dist, link; select=select, intercept=intercept, offset=offset)
 


### PR DESCRIPTION
Make it possible for packages using the MinCVmse and MinCV1se functions to use StableRNG for testing in multiple Julia versions and getting the same result.